### PR TITLE
Fix alarm can't be added

### DIFF
--- a/src/Widgets/AlarmTimeWidget.vala
+++ b/src/Widgets/AlarmTimeWidget.vala
@@ -193,7 +193,12 @@ namespace Hourglass.Widgets {
                 Hourglass.dbus_server.toggle_alarm (a.to_string ());
             });
 
-            Hourglass.dbus_server.add_alarm (a.to_string ());
+            try {
+                Hourglass.dbus_server.add_alarm (a.to_string ());
+            } catch (Error e) {
+                warning (e.message);
+            }
+
             update ();
         }
 


### PR DESCRIPTION
![Screenshot from 2019-10-26 09-17-10](https://user-images.githubusercontent.com/26003928/67610990-67033600-f7d1-11e9-8aad-2d2575230245.png)

WIP because now you can add alarms but the error message is still shown. Also, the app does not retain added timers once you restart it.
