### PR TITLE
Fix deprecations and warnings

### DIFF
--- a/data/com.github.sgpthomas.hourglass.appdata.xml.in
+++ b/data/com.github.sgpthomas.hourglass.appdata.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2017 Sam Thomas <sgpthomas@gmail.com> -->
 <component type="desktop-application">
-  <id>com.github.sgpthomas.hourglass.desktop</id>
+  <id>com.github.sgpthomas.hourglass</id>
   <metadata_license>CC0</metadata_license>
   <project_license>GPL-3</project_license>
   <name>Hourglass</name>

--- a/data/com.github.sgpthomas.hourglass.desktop.in.in
+++ b/data/com.github.sgpthomas.hourglass.desktop.in.in
@@ -13,8 +13,3 @@ X-GNOME-Keywords=Timer;Time;Clock;Hourglass;Alarm;
 StartupNotify=true
 X-GNOME-Gettext-Domain=@GETTEXT_PACKAGE@
 Actions=AboutDialog;
-
-[Desktop Action AboutDialog]
-Exec=hourglass --about
-Name=About Hourglass
-Name[lt]=Apie Hourglass

--- a/data/com.github.sgpthomas.hourglass.desktop.in.in
+++ b/data/com.github.sgpthomas.hourglass.desktop.in.in
@@ -12,4 +12,3 @@ Keywords=Timer;Time;Clock;Hourglass;Alarm;
 X-GNOME-Keywords=Timer;Time;Clock;Hourglass;Alarm;
 StartupNotify=true
 X-GNOME-Gettext-Domain=@GETTEXT_PACKAGE@
-Actions=AboutDialog;

--- a/src/Daemon/HourglassServer.vala
+++ b/src/Daemon/HourglassServer.vala
@@ -23,7 +23,7 @@ namespace HourglassDaemon {
     [DBus (name = "com.github.sgpthomas.hourglass")]
     public class Server : Object {
 
-        public void print_message (string msg) throws Error{
+        public void print_message (string msg) throws Error {
             message (msg);
         }
 

--- a/src/Daemon/HourglassServer.vala
+++ b/src/Daemon/HourglassServer.vala
@@ -23,25 +23,25 @@ namespace HourglassDaemon {
     [DBus (name = "com.github.sgpthomas.hourglass")]
     public class Server : Object {
 
-        public void print_message (string msg) {
+        public void print_message (string msg) throws Error{
             message (msg);
         }
 
-        public void show_notification (string summary, string body = "", string track = "") {
+        public void show_notification (string summary, string body = "", string track = "") throws Error {
             notification.show (summary, body, track);
         }
 
-        public void add_alarm (string alarm) {
+        public void add_alarm (string alarm) throws Error {
             message (alarm);
             manager.add_alarm (alarm);
         }
 
-        public void remove_alarm (string alarm) {
+        public void remove_alarm (string alarm) throws Error {
             message (alarm);
             manager.remove_alarm (alarm);
         }
 
-        public string[] get_alarm_list () {
+        public string[] get_alarm_list () throws Error {
             string[] list = {};
             foreach (string s in manager.alarm_list) {
                 list += s;
@@ -49,7 +49,7 @@ namespace HourglassDaemon {
             return list;
         }
 
-        public void toggle_alarm (string alarm) {
+        public void toggle_alarm (string alarm) throws Error {
             manager.toggle_alarm (alarm);
         }
 

--- a/src/Dialogs/MultiSelectPopover.vala
+++ b/src/Dialogs/MultiSelectPopover.vala
@@ -62,13 +62,6 @@ namespace Hourglass.Dialogs {
 			this.add (box);
         }
 
-        private void load_selected () {
-            foreach (int i in selected) {
-                var toggle = toggles[i];
-                toggle.active = true;
-            }
-        }
-
         public int[] get_selected () {
             selected = {};
             for (int i = 0; i < toggles.length; i++) {

--- a/src/Dialogs/NewAlarmDialog.vala
+++ b/src/Dialogs/NewAlarmDialog.vala
@@ -36,7 +36,7 @@ namespace Hourglass.Dialogs {
         private int[] repeat_days;
 
         //buttons
-        private HButtonBox final_actions;
+        private ButtonBox final_actions;
         private Button cancel_button;
         private Button delete_alarm_button;
         private Button create_alarm_button;
@@ -112,7 +112,7 @@ namespace Hourglass.Dialogs {
             repeat_combo_box.set_active (0);*/
 
             //final action button box
-            final_actions = new HButtonBox ();
+            final_actions = new ButtonBox (Gtk.Orientation.HORIZONTAL);
             final_actions.set_layout (Gtk.ButtonBoxStyle.END);
             final_actions.spacing = 12;
             final_actions.margin_top = 6;
@@ -137,8 +137,8 @@ namespace Hourglass.Dialogs {
             var main_grid = new Grid ();
             main_grid.row_spacing = 6;
             main_grid.column_spacing = 12;
-            main_grid.margin_left = 12;
-            main_grid.margin_right = 12;
+            main_grid.margin_start = 12;
+            main_grid.margin_end = 12;
 
             var label = new Label (_("Title:"));
             label.halign = Gtk.Align.END;

--- a/src/Hourglass.vala
+++ b/src/Hourglass.vala
@@ -35,27 +35,10 @@ namespace Hourglass {
     public MainWindow main_window;
 	public bool window_open;
 
-    public class HourglassApp : Granite.Application {
+    public class HourglassApp : Gtk.Application {
 
         construct {
-            program_name = Constants.APP_NAME;
-            exec_name = Constants.EXEC_NAME;
-            build_version = Constants.VERSION;
-
-            app_years = "2015-2017";
-            app_icon = Constants.ICON_NAME;
-            app_launcher = "com.github.sgpthomas.hourglass.desktop";
             application_id = "com.github.sgpthomas.client";
-
-            main_url = "https://github.com/sgpthomas/hourglass";
-            bug_url = "https://github.com/sgpthomas/hourglass/issues";
-            help_url = "https://github.com/sgpthomas/hourglass/issues";
-            translate_url = "http://translations.launchpad.net/hourglass";
-
-            about_authors = {"Sam Thomas <sgpthomas@gmail.com>"};
-            about_license_type = Gtk.License.GPL_3_0;
-            about_artists = {"Sam Thomas <sgpthomas@gmail.com>"};
-            about_translators = "Launchpad Translators";
         }
 
         //constructor

--- a/src/Services/DBusManager.vala
+++ b/src/Services/DBusManager.vala
@@ -20,12 +20,12 @@ namespace Hourglass.Services {
 
     [DBus (name = "com.github.sgpthomas.hourglass")]
     public interface HourglassClient : Object {
-        public abstract void print_message (string msg) throws IOError;
-        public abstract void show_notification (string summary, string body = "", string track = "") throws IOError;
-        public abstract void add_alarm (string alarm) throws IOError;
-        public abstract void remove_alarm (string alarm) throws IOError;
-        public abstract string[] get_alarm_list () throws IOError;
-        public abstract void toggle_alarm (string alarm) throws IOError;
+        public abstract void print_message (string msg) throws Error;
+        public abstract void show_notification (string summary, string body = "", string track = "") throws Error;
+        public abstract void add_alarm (string alarm) throws Error;
+        public abstract void remove_alarm (string alarm) throws Error;
+        public abstract string[] get_alarm_list () throws Error;
+        public abstract void toggle_alarm (string alarm) throws Error;
         public signal void should_refresh_client ();
     }
 
@@ -45,8 +45,8 @@ namespace Hourglass.Services {
 
                 client.print_message ("Client Starting");
 
-            } catch (IOError e) {
-                error ("%s", e.message);
+            } catch (Error e) {
+                error (e.message);
             }
         }
     }

--- a/src/Services/StyleManager.vala
+++ b/src/Services/StyleManager.vala
@@ -25,13 +25,9 @@ namespace Hourglass.Services {
         public static void add_stylesheet (string path) {
             var css_file = "/com/github/sgpthomas/hourglass/" + path;
             var provider = new CssProvider ();
-            try {
-                provider.load_from_resource (css_file);
-                StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), provider, Gtk.STYLE_PROVIDER_PRIORITY_USER);
-                message ("Loaded %s", css_file);
-            } catch (Error e) {
-                error ("Error with stylesheet: %s", e.message);
-            }
+            provider.load_from_resource (css_file);
+            StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), provider, Gtk.STYLE_PROVIDER_PRIORITY_USER);
+            message ("Loaded %s", css_file);
         }
     }
 }

--- a/src/Widgets/AlarmTimeWidget.vala
+++ b/src/Widgets/AlarmTimeWidget.vala
@@ -162,10 +162,14 @@ namespace Hourglass.Widgets {
 
         private void load_alarms () {
             clear_alarms ();
-            foreach (string str in Hourglass.dbus_server.get_alarm_list ()) {
-                if (Alarm.is_valid_alarm_string (str)) {
-                    append_alarm (Alarm.parse_string (str));
+            try {
+                foreach (string str in Hourglass.dbus_server.get_alarm_list ()) {
+                    if (Alarm.is_valid_alarm_string (str)) {
+                        append_alarm (Alarm.parse_string (str));
+                    }
                 }
+            } catch (Error e) {
+                warning (e.message);
             }
         }
 
@@ -190,10 +194,19 @@ namespace Hourglass.Widgets {
 
             a.state_toggled.connect ((b) => {
                 message ("toggled");
-                Hourglass.dbus_server.toggle_alarm (a.to_string ());
+                try {
+                    Hourglass.dbus_server.toggle_alarm (a.to_string ());
+                } catch (Error e) {
+                    warning (e.message);
+                }
             });
 
-            Hourglass.dbus_server.add_alarm (a.to_string ());
+            try {
+                Hourglass.dbus_server.add_alarm (a.to_string ());
+            } catch (Error e) {
+                warning (e.message);
+            }
+
             update ();
         }
 
@@ -212,14 +225,22 @@ namespace Hourglass.Widgets {
                 new_alarm_dialog = new NewAlarmDialog (window, (Alarm) widget);
 
                 new_alarm_dialog.edit_alarm.connect ((old_a, new_a) => {
-                    list_box.remove (old_a); //  remove old alarm
-                    Hourglass.dbus_server.remove_alarm (old_a.to_string ());
-                    append_alarm (new_a); // add new alarms
+                    try {
+                        list_box.remove (old_a); //  remove old alarm
+                        Hourglass.dbus_server.remove_alarm (old_a.to_string ());
+                        append_alarm (new_a); // add new alarms
+                    } catch (Error e) {
+                        warning (e.message);
+                    }
                 });
 
                 new_alarm_dialog.delete_alarm.connect ((a) => {
-                    list_box.remove (a);
-                    Hourglass.dbus_server.remove_alarm (a.to_string ());
+                    try {
+                        list_box.remove (a);
+                        Hourglass.dbus_server.remove_alarm (a.to_string ());
+                    } catch (Error e) {
+                        warning (e.message);
+                    }
                 });
                 new_alarm_dialog.show_all ();
             }

--- a/src/Widgets/Counter.vala
+++ b/src/Widgets/Counter.vala
@@ -107,7 +107,11 @@ namespace Hourglass.Widgets {
 					current_time = limit - (int)diff;
 				} else {
 					if (should_notify) {
-						Hourglass.dbus_server.show_notification (notify_summary, notify_body);
+                        try {
+                            Hourglass.dbus_server.show_notification (notify_summary, notify_body);
+                        } catch (Error e) {
+                            warning (e.message);
+                        }
 					}
 					stop ();
 					on_end ();

--- a/src/Window/MainWindow.vala
+++ b/src/Window/MainWindow.vala
@@ -32,7 +32,6 @@ namespace Hourglass.Window {
         private HourglassApp app;
 
         //header bar stuff
-        private AppMenu app_menu;
         private HeaderBar headerbar;
         //menu items
 
@@ -74,8 +73,6 @@ namespace Hourglass.Window {
             widget_list += new StopwatchTimeWidget (this);
             widget_list += new TimerTimeWidget (this);
 
-            setup_app_menu ();
-
             setup_headerbar ();
 
             setup_layout ();
@@ -86,13 +83,6 @@ namespace Hourglass.Window {
             connect_signals ();
 
             stack.set_visible_child_name (Hourglass.saved.last_open_widget);
-        }
-
-        private void setup_app_menu () {
-            //create app menu
-            var m = new Gtk.Menu ();
-
-            app_menu = app.create_appmenu (m);
         }
 
         private void setup_headerbar () {

--- a/src/Window/MainWindow.vala
+++ b/src/Window/MainWindow.vala
@@ -88,7 +88,6 @@ namespace Hourglass.Window {
         private void setup_headerbar () {
             //headerbar
             headerbar = new HeaderBar ();
-            //headerbar.pack_end (app_menu);
             headerbar.set_custom_title (stack_switcher);
             headerbar.set_show_close_button (true);
             this.set_titlebar (headerbar);


### PR DESCRIPTION
## Changes Summary
- Fix deprecated `Granite.Appliaction`, `Granite.Widgets.AppMenu`, `Gtk.HButtonBox`, `Gtk.Widget.margin_left`, and `Gtk.Widget.margin_right` (fixes #54)
- Add lacking `throws` and `try{}…catch{}`
- Remove unused method `load_selected`
- Remove unnecessary `try{}…catch{}` when loading CSS
- AppData: Fix deprecated `.desktop` in id
