### PR TITLE
Improve look of create/edit alarm dialog

### DIFF
--- a/src/Dialogs/NewAlarmDialog.vala
+++ b/src/Dialogs/NewAlarmDialog.vala
@@ -117,12 +117,12 @@ namespace Hourglass.Dialogs {
             final_actions.spacing = 12;
             final_actions.margin_top = 6;
 
-            var create_alarm_button_label = edit_alarm_enabled ? _("Edit") : _("Create");
+            var create_alarm_button_label = edit_alarm_enabled ? _("Save Changes") : _("Create Alarm");
 
             cancel_button = new Button.with_label (_("Cancel"));
 
             delete_alarm_button = new Button.with_label (_("Delete"));
-            delete_alarm_button.get_style_context ().add_class ("red-button");
+            delete_alarm_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
             create_alarm_button = new Button.with_label (create_alarm_button_label);
             create_alarm_button.get_style_context ().add_class ("green-button");
 
@@ -140,17 +140,17 @@ namespace Hourglass.Dialogs {
             main_grid.margin_left = 12;
             main_grid.margin_right = 12;
 
-            var label = new Label (_("Title:"));
+            var label = new Granite.HeaderLabel (_("Title:"));
             label.halign = Gtk.Align.END;
             main_grid.attach (label, 0, 0, 1, 1);
             main_grid.attach (title_entry, 1, 0, 1, 1);
 
-            label = new Label (_("Choose a time:"));
+            label = new Granite.HeaderLabel (_("Time:"));
             label.halign = Gtk.Align.END;
             main_grid.attach (label , 0, 1, 1, 1);
             main_grid.attach (time_picker, 1, 1, 1, 1);
 
-            label = new Label (_("Choose a date:"));
+            label = new Granite.HeaderLabel (_("Date:"));
             label.halign = Gtk.Align.END;
             main_grid.attach (label, 0, 2, 1, 1);
             main_grid.attach (date_picker, 1, 2, 1, 1);
@@ -160,7 +160,7 @@ namespace Hourglass.Dialogs {
             main_grid.attach (label, 0, 3, 1, 1);
             main_grid.attach (repeat_combo_box, 1, 3, 1, 1);*/
 
-            label = new Label (_("Repeat:"));
+            label = new Granite.HeaderLabel (_("Repeat:"));
             label.halign = Gtk.Align.END;
             main_grid.attach (label, 0, 3, 1, 1);
             main_grid.attach (repeat_day_picker, 1, 3, 1, 1);

--- a/src/Dialogs/NewAlarmDialog.vala
+++ b/src/Dialogs/NewAlarmDialog.vala
@@ -117,7 +117,7 @@ namespace Hourglass.Dialogs {
             final_actions.spacing = 12;
             final_actions.margin_top = 6;
 
-            var create_alarm_button_label = edit_alarm_enabled ? _("Save Changes") : _("Create Alarm");
+            var create_alarm_button_label = edit_alarm_enabled ? _("Save") : _("Create Alarm");
 
             cancel_button = new Button.with_label (_("Cancel"));
 


### PR DESCRIPTION
Fixes #48

## Before
![Screenshot from 2020-04-19 19-29-20](https://user-images.githubusercontent.com/26003928/79685627-2b739100-8275-11ea-8f06-957e4cf2e6ef.png)
![Screenshot from 2020-04-19 19-29-32](https://user-images.githubusercontent.com/26003928/79685628-2d3d5480-8275-11ea-851b-e6f0a9e0cf45.png)

## After
![Screenshot from 2020-04-19 19-36-47](https://user-images.githubusercontent.com/26003928/79685631-2f071800-8275-11ea-9cef-ba972654369b.png)
![Screenshot from 2020-04-19 19-40-39](https://user-images.githubusercontent.com/26003928/79685756-11867e00-8276-11ea-8375-07d477e4eb81.png)

## Changes Summary
I addressed the following points mentioned in #48:
- Fix button label shadows
- Update the color of the delete button (the red color is very slightly different from Calendar)
- Change "Choose a time:" to "Time:" and "Choose a date:" to "Date:".
- Change "Edit" button in edit dialog to "Save Changes"
- Change "Create" button in edit dialog to "Create Alarm"

I personally don't think we need to address the following point:

- Change Edit and Create button colors from green to blue (like Calendar)
