### PR TITLE
Change shortened days

### DIFF
--- a/src/Dialogs/MultiSelectPopover.vala
+++ b/src/Dialogs/MultiSelectPopover.vala
@@ -29,7 +29,7 @@ namespace Hourglass.Dialogs {
         // check buttons
         private Gtk.ToggleButton[] toggles;
 
-        private string[] shortened_days = {_("Su"), _("M"), _("T"), _("W"), _("Th"), _("F"), _("Sa")};
+        private string[] shortened_days = {_("Sun"), _("Mon"), _("Tue"), _("Wed"), _("Thu"), _("Fri"), _("Sat")};
 
         // selected
         private int[] selected;
@@ -80,7 +80,7 @@ namespace Hourglass.Dialogs {
         }
 
         public static string selected_to_string (int[] sel) {
-            string[] shortened_days = {_("Su"), _("M"), _("T"), _("W"), _("Th"), _("F"), _("Sa")};
+            string[] shortened_days = {_("Sun"), _("Mon"), _("Tue"), _("Wed"), _("Thu"), _("Fri"), _("Sat")};
 
             var str = "";
             


### PR DESCRIPTION
The current shortened days do not follows the standards and this is bad for translation.
Following the standard with the 3 first letters of each day is better.

This would be : Sun, Mon, Tue, Wed, Thu, Fri, Sat

For example in French it will give : Dim, Lun, Mar, Mer, Jeu, Ven, Sam

Which is very common.

I made the appropriate changes but I still have an issue with the popover alignment:

![image](https://user-images.githubusercontent.com/45366162/80240788-bf24d300-8662-11ea-973a-93e025e55c62.png)

The popover is not centered anymore and I didn't find out how to change it. Any ideas?