### PR TITLE
Improve Meson and l10n

### DIFF
--- a/data/com.github.sgpthomas.hourglass.desktop.in.in
+++ b/data/com.github.sgpthomas.hourglass.desktop.in.in
@@ -11,4 +11,3 @@ Categories=GNOME;GTK;Utility;
 Keywords=Timer;Time;Clock;Hourglass;Alarm;
 X-GNOME-Keywords=Timer;Time;Clock;Hourglass;Alarm;
 StartupNotify=true
-X-GNOME-Gettext-Domain=@GETTEXT_PACKAGE@

--- a/meson.build
+++ b/meson.build
@@ -11,14 +11,11 @@ add_project_arguments(
 )
 
 conf_data = configuration_data()
-conf_data.set('GETTEXT_PACKAGE', meson.project_name())
 conf_data.set('EXEC_NAME', meson.project_name())
 conf_data.set('DAEMON_EXEC_NAME', meson.project_name() + '-daemon')
 conf_data.set('DAEMON_NAME', meson.project_name() + '-daemon')
 conf_data.set('ICON_NAME', meson.project_name())
 conf_data.set('APP_NAME', 'Hourglass')
-conf_data.set('VERSION', meson.project_version())
-conf_data.set('DATADIR', get_option('datadir'))
 
 config_file = configure_file(
     input: join_paths('src', 'Config.vala.in'),

--- a/po/extra/meson.build
+++ b/po/extra/meson.build
@@ -3,5 +3,6 @@ i18n.gettext('extra',
         '--directory=' + meson.source_root(),
         '--from-code=UTF-8'
     ],
+    install: false,
     preset: 'glib'
 )

--- a/src/Config.vala.in
+++ b/src/Config.vala.in
@@ -17,9 +17,6 @@
 */
 
 namespace Constants {
-    public const string DATADIR = "@DATADIR@";
-    public const string GETTEXT_PACKAGE = "@GETTEXT_PACKAGE@";
-    public const string VERSION = "@VERSION@";
     public const string APP_NAME = "@APP_NAME@";
     public const string EXEC_NAME = "@EXEC_NAME@";
     public const string ICON_NAME = "@ICON_NAME@";

--- a/src/Hourglass.vala
+++ b/src/Hourglass.vala
@@ -57,13 +57,6 @@ namespace Hourglass {
             /* Managers */
             dbus_manager = new DBusManager ();
             dbus_server = dbus_manager.client;
-
-            /* Translation support */
-            Intl.setlocale (LocaleCategory.ALL, "");
-            string langpack_dir = Path.build_filename (Constants.DATADIR, "locale");
-            Intl.bindtextdomain (Constants.GETTEXT_PACKAGE, langpack_dir);
-            Intl.bind_textdomain_codeset (Constants.GETTEXT_PACKAGE, "UTF-8");
-            Intl.textdomain (Constants.GETTEXT_PACKAGE);
         }
 
         public override void activate () {


### PR DESCRIPTION
- Fix the UI is not shown as translated
- Remove no longer used project constants
- Don't install extra translation files
