### PR TITLE
Move the delete button in the action bar

### DIFF
--- a/src/Dialogs/NewAlarmDialog.vala
+++ b/src/Dialogs/NewAlarmDialog.vala
@@ -38,7 +38,6 @@ namespace Hourglass.Dialogs {
         //buttons
         private ButtonBox final_actions;
         private Button cancel_button;
-        private Button delete_alarm_button;
         private Button create_alarm_button;
 
         //should display edit alarm dialog instead
@@ -48,7 +47,6 @@ namespace Hourglass.Dialogs {
         //signals
         public signal void create_alarm (Alarm a);
         public signal void edit_alarm (Alarm old_alarm, Alarm new_alarm);
-        public signal void delete_alarm (Alarm a);
 
         public NewAlarmDialog (Gtk.Window? parent, Alarm? alarm = null) {
             //assign the dialog a parent if one is provided
@@ -121,14 +119,8 @@ namespace Hourglass.Dialogs {
 
             cancel_button = new Button.with_label (_("Cancel"));
 
-            delete_alarm_button = new Button.with_label (_("Delete"));
-            delete_alarm_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
             create_alarm_button = new Button.with_label (create_alarm_button_label);
             create_alarm_button.get_style_context ().add_class ("green-button");
-
-            if (edit_alarm_enabled) {
-                final_actions.pack_start (delete_alarm_button);
-            }
 
             final_actions.pack_start (cancel_button);
             final_actions.pack_start (create_alarm_button);
@@ -217,11 +209,6 @@ namespace Hourglass.Dialogs {
                 } else {
                     create_alarm (a);
                 }
-                this.destroy ();
-            });
-
-            delete_alarm_button.clicked.connect (() => {
-                delete_alarm (alarm);
                 this.destroy ();
             });
 


### PR DESCRIPTION
I guess it's more clear what to do when a user wants to remove an alarm

## Before
![2020-09-26 06 52 52 のスクリーンショット](https://user-images.githubusercontent.com/26003928/94319123-eb9f9b00-ffc4-11ea-8360-3984768299a8.png)

## After
![Screenshot from 2020-09-26 06-51-50](https://user-images.githubusercontent.com/26003928/94319066-cf9bf980-ffc4-11ea-9ce5-8ab7df076ebb.png)
