### PR TITLE
Remove update frequency gsettings

### DIFF
--- a/schemas/com.github.sgpthomas.hourglass.gschema.xml
+++ b/schemas/com.github.sgpthomas.hourglass.gschema.xml
@@ -39,11 +39,6 @@
 
     </schema>
     <schema path="/com/github/sgpthomas/hourglass/settings/" id="com.github.sgpthomas.hourglass.settings" gettext-domain="hourglass">
-        <key name="update-frequency" type="i">
-            <default>15000</default>
-            <summary>The frequency at which hourglass checks for alarms.</summary>
-            <description>Time in milliseconds. Requires restart of daemon to take effect.</description>
-        </key>
         <key name="sound" type="s">
             <default>'alarm-clock-elapsed'</default>
             <summary>Name of sound for notification.</summary>

--- a/src/Daemon/HourglassDaemon.vala
+++ b/src/Daemon/HourglassDaemon.vala
@@ -52,12 +52,8 @@ namespace HourglassDaemon {
 
             hold ();
 
-            // check to make sure that update frequency is below 60,000
-            if (HourglassDaemon.settings.get_int ("update-frequency") >= 60000) {
-                HourglassDaemon.settings.set_int ("update-frequency", 15000);
-            }
-
-            Timeout.add (HourglassDaemon.settings.get_int ("update-frequency"), manager.check_alarm);
+            // Check alarm per second
+            Timeout.add (1000, manager.check_alarm);
         }
 
         public override void activate () {


### PR DESCRIPTION
This gsettings allows users the delay before notifications but I can't imagine that users want to need it. Users should expect the alarm rings as soon as the time come.
