### PR TITLE
Explicit year

### DIFF
--- a/src/Daemon/AlarmManager.vala
+++ b/src/Daemon/AlarmManager.vala
@@ -180,16 +180,18 @@ namespace HourglassDaemon {
             string[] date_parts = parts[2].split ("-");
             var alarm_month = int.parse (date_parts[0]);
             var alarm_day = int.parse (date_parts[1]);
+            var alarm_year = int.parse (date_parts[2]);
 
             //create booleans that checks same date and time
-            bool same_day = alarm_day == now.get_day_of_month ();
             bool same_month = alarm_month == now.get_month ();
+            bool same_day = alarm_day == now.get_day_of_month ();
+            bool same_year = alarm_year == now.get_year ();
             bool same_hour = alarm_hour == now.get_hour ();
             bool same_min = alarm_min == now.get_minute ();
 
             if (same_hour && same_min) {
                 //if today, alarm goes off
-                if (same_day && same_month) {
+                if (same_day && same_month && same_year) {
                     return true;
                 }
 

--- a/src/Widgets/Alarm.vala
+++ b/src/Widgets/Alarm.vala
@@ -120,8 +120,10 @@ public class Hourglass.Widgets.Alarm : Gtk.ListBoxRow {
         //add date
         str += time.get_month ().to_string ();
         str += "-";
-
         str += time.get_day_of_month ().to_string ();
+        str += "-";
+        str += time.get_year ().to_string ();
+
         str += Utils.ALARM_INFO_SEPARATOR;
 
         //add repeat days
@@ -165,8 +167,9 @@ public class Hourglass.Widgets.Alarm : Gtk.ListBoxRow {
         var date_string_parts = parts[2].split ("-");
         var month = int.parse (date_string_parts[0]);
         var day = int.parse (date_string_parts[1]);
+        var year = int.parse (date_string_parts[2]);
 
-        var time = new GLib.DateTime.local (new GLib.DateTime.now_local ().get_year (), month, day, hour, min, 0);
+        var time = new GLib.DateTime.local (year, month, day, hour, min, 0);
 
         //repeat
         int[] repeat_days = {};


### PR DESCRIPTION
Even if you add an alarm in the next year of today it will be notified today. This become a problem when you create an alarm for tomorrow on Dec 31 because the timer is set to Jan 1 of that year, 364 days ago―not of the next year, tomorrow.
