### PR TITLE
Fix the app exits if the window has been iconified

### DIFF
--- a/src/Objects/Counter.vala
+++ b/src/Objects/Counter.vala
@@ -89,11 +89,6 @@ public class Hourglass.Objects.Counter : GLib.Object {
         }
 
         stopped ();
-
-        if (!Hourglass.window_open) {
-            Hourglass.saved.set_boolean ("timer-state", false); // prevents timer from going off again when you start up the app
-            Gtk.main_quit ();
-        }
     }
 
     private bool tick () {


### PR DESCRIPTION
Fixes #168

Setting `timer-state` to `false` is also done after we catching `stopped` signal, so remove everything here
