### PR TITLE
Counter: Restore started time on end

### DIFF
--- a/src/Objects/Counter.vala
+++ b/src/Objects/Counter.vala
@@ -88,13 +88,13 @@ public class Hourglass.Objects.Counter : GLib.Object {
     }
 
     private bool tick () {
-        var diff = (new DateTime.now_local ()).difference (start_time);
+        var diff = (int64) (new DateTime.now_local ()).difference (start_time);
 
         if (direction == CountDirection.UP) {
-            current_time = (int64)diff + last_time;
+            current_time = diff + last_time;
         } else {
             if (current_time >= 0) {
-                current_time = limit - (int64)diff;
+                current_time = limit - diff;
             } else {
                 if (should_notify) {
                     try {
@@ -104,6 +104,7 @@ public class Hourglass.Objects.Counter : GLib.Object {
                     }
                 }
 
+                current_time = limit;
                 stop ();
                 ended ();
             }

--- a/src/Objects/Counter.vala
+++ b/src/Objects/Counter.vala
@@ -31,11 +31,7 @@ public class Hourglass.Objects.Counter : GLib.Object {
 
     public CountDirection direction { get; construct; }
 
-    public bool is_active {
-        get {
-            return current_time > 0;
-        }
-    }
+    public bool is_active { get; private set; }
 
     // in milliseconds
     public int64 current_time { get; private set; default = 0; }
@@ -74,6 +70,7 @@ public class Hourglass.Objects.Counter : GLib.Object {
             timeout_id = Timeout.add (10, tick);
         }
 
+        is_active = true;
         started ();
     }
 
@@ -84,6 +81,7 @@ public class Hourglass.Objects.Counter : GLib.Object {
             timeout_id = 0;
         }
 
+        is_active = false;
         stopped ();
     }
 


### PR DESCRIPTION
Fixes #155

We've been using `current_time` to check if the timer is active so now switch that check to another approach
