### PR TITLE
Revert "MultiSelectPopover: DRY shortened days"

### DIFF
--- a/src/Dialogs/MultiSelectPopover.vala
+++ b/src/Dialogs/MultiSelectPopover.vala
@@ -7,7 +7,7 @@ public class Hourglass.Dialogs.MultiSelectPopover : Gtk.Popover {
     private Gtk.ToggleButton[] toggles;
 
     private int[]? selected_days;
-    private static string[] shortened_days = {
+    private string[] shortened_days = {
         _("Sun"), _("Mon"), _("Tue"), _("Wed"), _("Thu"), _("Fri"), _("Sat")
     };
 
@@ -60,6 +60,10 @@ public class Hourglass.Dialogs.MultiSelectPopover : Gtk.Popover {
     }
 
     public static string selected_to_string (int[] selected_days) {
+        string[] shortened_days = {
+            _("Sun"), _("Mon"), _("Tue"), _("Wed"), _("Thu"), _("Fri"), _("Sat")
+        };
+
         string str = "";
         if (selected_days.length == 7) {
             str = _("Every Day");


### PR DESCRIPTION
This causes a silent segumentation fault if you create a repeated alarm, close the app, and try to reopen it
