### PR TITLE
Fix the condition of closing the app window being reversed

### DIFF
--- a/src/Hourglass.vala
+++ b/src/Hourglass.vala
@@ -36,7 +36,7 @@ namespace Hourglass {
                 return;
             }
 
-            main_window = new Hourglass.Window.MainWindow ();
+            main_window = new Hourglass.Window.MainWindow (this);
 
             if (Hourglass.saved.get_boolean ("is-maximized")) {
                 main_window.maximize ();
@@ -55,7 +55,6 @@ namespace Hourglass {
             }
 
             main_window.show_all ();
-            Gtk.main ();
         }
 
         public static void spawn_daemon () {
@@ -71,13 +70,12 @@ namespace Hourglass {
         }
     }
 
-    public static void main (string[] args) {
+    public static int main (string[] args) {
         HourglassApp.spawn_daemon ();
 
         Gtk.init (ref args);
         Hdy.init ();
 
-        HourglassApp app = new HourglassApp ();
-        app.run (args);
+        return new HourglassApp ().run (args);
     }
 }

--- a/src/Window/MainWindow.vala
+++ b/src/Window/MainWindow.vala
@@ -9,9 +9,10 @@ public class Hourglass.Window.MainWindow : Hdy.Window {
     private Gtk.Stack stack;
     private Hourglass.Views.AbstractView[] widget_list;
 
-    public MainWindow () {
+    public MainWindow (Gtk.Application app) {
         Object (
-            title: "Hourglass"
+            title: "Hourglass",
+            application: app
         );
     }
 
@@ -72,13 +73,12 @@ public class Hourglass.Window.MainWindow : Hdy.Window {
         });
 
         delete_event.connect (() => {
-            on_delete ();
-            return true;
+            return on_delete ();
         });
 
         key_press_event.connect ((key) => {
             if (Gdk.ModifierType.CONTROL_MASK in key.state && key.keyval == Gdk.Key.q) {
-                on_delete ();
+                return on_delete ();
             }
 
             return false;
@@ -98,10 +98,10 @@ public class Hourglass.Window.MainWindow : Hdy.Window {
         var visible = (Hourglass.Views.AbstractView) stack.get_visible_child ();
         if (visible.should_keep_open) {
             iconify ();
-            return false;
-        } else {
-            Gtk.main_quit ();
             return true;
+        } else {
+            destroy ();
+            return false;
         }
     }
 }


### PR DESCRIPTION
Replace `Gtk.main()` and `Gtk.main_quit()` which is deprecated in GTK4 while we're here