### PR TITLE
Flatpak: Use id instead of deprecated app-id

### DIFF
--- a/com.github.sgpthomas.hourglass.yml
+++ b/com.github.sgpthomas.hourglass.yml
@@ -1,4 +1,4 @@
-app-id: com.github.sgpthomas.hourglass
+id: com.github.sgpthomas.hourglass
 runtime: io.elementary.Platform
 runtime-version: '8'
 sdk: io.elementary.Sdk


### PR DESCRIPTION
From https://docs.flatpak.org/en/latest/flatpak-builder-command-reference.html:

> Note, "app-id" is deprecated and preserved only for backwards compatibility.