### PR TITLE
fix: metainfo: Remove hourglass-daemon from provides

### DIFF
--- a/data/com.github.sgpthomas.hourglass.metainfo.xml.in.in
+++ b/data/com.github.sgpthomas.hourglass.metainfo.xml.in.in
@@ -65,7 +65,6 @@
 
   <provides>
     <binary>hourglass</binary>
-    <binary>hourglass-daemon</binary>
   </provides>
 
   <releases>


### PR DESCRIPTION
The daemon is no longer provided as a separate binary since #230 so this is just a leftover.
